### PR TITLE
réparer la non apparition de la fenêtre pour les mois pouvant commenc…

### DIFF
--- a/data/librazik_tips
+++ b/data/librazik_tips
@@ -19,7 +19,7 @@ is_display_prevented(){
     
     last_month_line=$(grep ^"month=" "$lzk_config_file"|head -n 1)
     last_month=${last_month_line#*=}
-    month=$(date +%m)
+    month=$(date +%m| sed 's/^0//')
     [[ "$month" == "$last_month" ]] && return 0
     return 1
 }


### PR DESCRIPTION
…er par un zéro (jusqu'à septembre (09) )

Voilà, c'était une erreur de comparaison entre des mois en chiffre en '1' contre '01' (pour janvier).
Ça marchera même avant octobre du coup.